### PR TITLE
Add flags to turn off some features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsondata-editor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -19,7 +19,7 @@ import ModalPrimitive from "./ModalPrimitive";
  * @returns {JSX.Element}
  *
  */
-export default function Editor({input, jsonBoxRef, onChange}) {
+export default function Editor({input, jsonBoxRef, onChange, hideInsertObjectButton, expandToGeneration}) {
 
     const emptyValues = {
             path : undefined,
@@ -236,12 +236,13 @@ export default function Editor({input, jsonBoxRef, onChange}) {
             }
 
             <div key={"jsonBody"} className={styles.JsonViewOutput}>
-
-                <div className={styles.insertBanner} style={{backgroundColor: focusOnBanner ? userStyle.banner.hoverColor : userStyle.themes.color}}
-                     onMouseOver={()=>{setFocusOnBanner(true)}} onMouseLeave={()=>{setFocusOnBanner(false)}} onClick={()=>{
-                         jsonData !== undefined ? createModal("") : setSelectType(true)}}>
-                    <span className={styles.bannerSpan} style={{color: userStyle.banner.fontColor, font: userStyle.banner.font}}> + Insert Object</span>
-                </div>
+                {!hideInsertObjectButton &&
+                  <div className={styles.insertBanner} style={{backgroundColor: focusOnBanner ? userStyle.banner.hoverColor : userStyle.themes.color}}
+                      onMouseOver={()=>{setFocusOnBanner(true)}} onMouseLeave={()=>{setFocusOnBanner(false)}} onClick={()=>{
+                          jsonData !== undefined ? createModal("") : setSelectType(true)}}>
+                      <span className={styles.bannerSpan} style={{color: userStyle.banner.fontColor, font: userStyle.banner.font}}> + Insert Object</span>
+                  </div>
+                }
                 <div className={styles.jsonListOutput} ref={jsonListOutput}>
                     <JsonView key={"DisplayJson"}
                               input={jsonData}
@@ -250,6 +251,7 @@ export default function Editor({input, jsonBoxRef, onChange}) {
                               deleteNode={deleteNode}
                               setPrimitive={setPrimitive}
                               createModal={createModal}
+                              expandToGeneration={expandToGeneration}
                               />
                 </div>
             </div>

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -19,7 +19,7 @@ import ModalPrimitive from "./ModalPrimitive";
  * @returns {JSX.Element}
  *
  */
-export default function Editor({input, jsonBoxRef, onChange, hideInsertObjectButton, expandToGeneration}) {
+export default function Editor({input, jsonBoxRef, onChange, hideInsertObjectButton, expandToGeneration, isReadOnly}) {
 
     const emptyValues = {
             path : undefined,
@@ -236,7 +236,7 @@ export default function Editor({input, jsonBoxRef, onChange, hideInsertObjectBut
             }
 
             <div key={"jsonBody"} className={styles.JsonViewOutput}>
-                {!hideInsertObjectButton &&
+                {!hideInsertObjectButton && !isReadOnly &&
                   <div className={styles.insertBanner} style={{backgroundColor: focusOnBanner ? userStyle.banner.hoverColor : userStyle.themes.color}}
                       onMouseOver={()=>{setFocusOnBanner(true)}} onMouseLeave={()=>{setFocusOnBanner(false)}} onClick={()=>{
                           jsonData !== undefined ? createModal("") : setSelectType(true)}}>
@@ -252,6 +252,7 @@ export default function Editor({input, jsonBoxRef, onChange, hideInsertObjectBut
                               setPrimitive={setPrimitive}
                               createModal={createModal}
                               expandToGeneration={expandToGeneration}
+                              isReadOnly={isReadOnly}
                               />
                 </div>
             </div>

--- a/src/JsonView.js
+++ b/src/JsonView.js
@@ -18,6 +18,7 @@ import UserContext from "./UserContext";
  * @param createModal creates edit modal component
  * @param indent indentation
  * @param needLeaf indicates "", [] or {}
+ * @param expandToGeneration Show content if the child's generation index is > expandToGeneration
 
  * @returns {JSX.Element|[]}
  */
@@ -31,6 +32,7 @@ export default function JsonView(
         createModal,
         indent = 1,
         needLeaf = true,
+        expandToGeneration = undefined
     }) {
 
     const typeOfInput = TypeOfValue(input)
@@ -59,7 +61,7 @@ export default function JsonView(
                 <div className={styles.dataNode} onClick={()=>{ changePrimitive(input)}}>
                     <div className={styles.needLeaf} style={{backgroundColor: focusOnLine ? userStyle.themes.hoverColor : ''}} onMouseOver={()=>{setFocusOnLine(true)}} onMouseLeave={()=>{setFocusOnLine(false)}}>
                         <div>
-                            <JsonView jsonPath={jsonPath} input={input} indent={indent} needLeaf={false}/>
+                            <JsonView jsonPath={jsonPath} input={input} indent={indent} needLeaf={false} expandToGeneration={expandToGeneration} />
                         </div>
                         {focusOnLine &&
                         <div className={styles.rightContainer}
@@ -158,7 +160,7 @@ export default function JsonView(
                 <ViewNode key={jsonPath + "/" +key} jsonPath={jsonPath} field={key} value={value}
                           indent={indent} isInArray={input instanceof Array}
                           deleteNode={deleteNode} setPrimitive={setPrimitive} createModal={createModal} createEditModal={createEditModal}
-                          jsonListOutput={jsonListOutput}/>
+                          jsonListOutput={jsonListOutput} expandToGeneration={expandToGeneration}/>
             )
         })
     )
@@ -178,12 +180,13 @@ export default function JsonView(
  * @param setPrimitive changes a primitive value
  * @param createModal creates edit modal component
  * @param createEditModal saves information with current position node of for modal editor when a user clicks add or edit button
+ * @param expandToGeneration Show content if the child's generation index is > expandToGeneration
  * @returns {JSX.Element}
  *
  */
-function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, deleteNode, setPrimitive, createModal, createEditModal}) {
+function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, deleteNode, setPrimitive, createModal, createEditModal, expandToGeneration}) {
 
-    const [showContent, setShowContent] = useState(true)
+    const [showContent, setShowContent] = useState(expandToGeneration === undefined ? true : (jsonPath.match(/\//g) || []).length <= expandToGeneration)
     const [focusOnLine, setFocusOnLine] = useState(false)
     const isList = value instanceof Object
     // current clickNode position
@@ -248,7 +251,7 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
                     }
 
                     {
-                        !isList && <JsonView input={value} needLeaf={false}/>
+                        !isList && <JsonView input={value} needLeaf={false} expandToGeneration={expandToGeneration} />
                     }
                 </div>
 
@@ -258,7 +261,7 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
                 isList && showContent &&
                 <JsonView jsonPath={jsonPath + '/' + field} input={value} indent={indent + 1}
                              deleteNode={deleteNode} setPrimitive={setPrimitive} needLeaf={false}
-                             jsonListOutput={jsonListOutput} createModal={createModal}/>
+                             jsonListOutput={jsonListOutput} createModal={createModal} expandToGeneration={expandToGeneration}/>
             }
 
         </div>

--- a/src/JsonView.js
+++ b/src/JsonView.js
@@ -19,6 +19,7 @@ import UserContext from "./UserContext";
  * @param indent indentation
  * @param needLeaf indicates "", [] or {}
  * @param expandToGeneration Show content if the child's generation index is > expandToGeneration
+ * @param isReadOnly true: do not show overlay to edit and delete
 
  * @returns {JSX.Element|[]}
  */
@@ -32,7 +33,8 @@ export default function JsonView(
         createModal,
         indent = 1,
         needLeaf = true,
-        expandToGeneration = undefined
+        expandToGeneration = undefined,
+        isReadOnly = false
     }) {
 
     const typeOfInput = TypeOfValue(input)
@@ -61,9 +63,9 @@ export default function JsonView(
                 <div className={styles.dataNode} onClick={()=>{ changePrimitive(input)}}>
                     <div className={styles.needLeaf} style={{backgroundColor: focusOnLine ? userStyle.themes.hoverColor : ''}} onMouseOver={()=>{setFocusOnLine(true)}} onMouseLeave={()=>{setFocusOnLine(false)}}>
                         <div>
-                            <JsonView jsonPath={jsonPath} input={input} indent={indent} needLeaf={false} expandToGeneration={expandToGeneration} />
+                            <JsonView jsonPath={jsonPath} input={input} indent={indent} needLeaf={false} expandToGeneration={expandToGeneration} isReadOnly={isReadOnly} />
                         </div>
-                        {focusOnLine &&
+                        {!isReadOnly && focusOnLine &&
                         <div className={styles.rightContainer}
                              style={{backgroundImage: 'linear-gradient(to right, transparent 0, ' + userStyle.themes.hoverColor + ' 0.5em)'}}>
                             <div style={{
@@ -125,7 +127,7 @@ export default function JsonView(
                                 <span>{JSON.stringify(input)}</span>
                             </div>
                         </div>
-                        { focusOnLine &&
+                        {!isReadOnly && focusOnLine &&
                         <div className={styles.rightContainer}
                              style={{ backgroundImage: 'linear-gradient(to right, transparent 0, ' + userStyle.themes.hoverColor + ' 0.5em)'}}>
                             <div style={{
@@ -160,7 +162,7 @@ export default function JsonView(
                 <ViewNode key={jsonPath + "/" +key} jsonPath={jsonPath} field={key} value={value}
                           indent={indent} isInArray={input instanceof Array}
                           deleteNode={deleteNode} setPrimitive={setPrimitive} createModal={createModal} createEditModal={createEditModal}
-                          jsonListOutput={jsonListOutput} expandToGeneration={expandToGeneration}/>
+                          jsonListOutput={jsonListOutput} expandToGeneration={expandToGeneration} isReadOnly={isReadOnly}/>
             )
         })
     )
@@ -181,10 +183,11 @@ export default function JsonView(
  * @param createModal creates edit modal component
  * @param createEditModal saves information with current position node of for modal editor when a user clicks add or edit button
  * @param expandToGeneration Show content if the child's generation index is > expandToGeneration
+ * @param isReadOnly true: do not show edit && delete buttons
  * @returns {JSX.Element}
  *
  */
-function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, deleteNode, setPrimitive, createModal, createEditModal, expandToGeneration}) {
+function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, deleteNode, setPrimitive, createModal, createEditModal, expandToGeneration, isReadOnly}) {
 
     const [showContent, setShowContent] = useState(expandToGeneration === undefined ? true : (jsonPath.match(/\//g) || []).length <= expandToGeneration)
     const [focusOnLine, setFocusOnLine] = useState(false)
@@ -197,10 +200,14 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
         <div className={styles.dataContainer}>
             <div className={styles.dataNode} ref={inputRef}>
                 <div className={styles.clickNode}
-                     style={{backgroundColor: focusOnLine ? userStyle.themes.hoverColor : ''}} onMouseOver={()=>{setFocusOnLine(true)}} onMouseLeave={()=>{setFocusOnLine(false)}}
+                     style={{backgroundColor: focusOnLine ? userStyle.themes.hoverColor : '', cursor: isReadOnly ? 'default': 'pointer'}} onMouseOver={()=>{setFocusOnLine(!isReadOnly && true)}} onMouseLeave={()=>{setFocusOnLine(false)}}
                      onClick={(e)=>{
                     e.stopPropagation();
                     e.preventDefault();
+
+                    if (isReadOnly) {
+                      return;
+                    }
 
                     if(isList) {
                         setShowContent(!showContent)
@@ -227,7 +234,7 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
                         </div>
                     </div>
 
-                    { focusOnLine &&
+                    { !isReadOnly && focusOnLine &&
                     <div className={styles.rightContainer} style={{ backgroundImage: 'linear-gradient(to right, transparent 0, ' + userStyle.themes.hoverColor  + ' 0.5em)'}}>
                         <div style={{font: userStyle.values.font, fontStyle:"italic", color:userStyle.themes.color}}><TypeToString input={value}/></div>
                         <div className={styles.rightButton}>
@@ -251,7 +258,7 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
                     }
 
                     {
-                        !isList && <JsonView input={value} needLeaf={false} expandToGeneration={expandToGeneration} />
+                        !isList && <JsonView input={value} needLeaf={false} expandToGeneration={expandToGeneration} isReadOnly={isReadOnly} />
                     }
                 </div>
 
@@ -261,7 +268,7 @@ function ViewNode({ jsonPath, field, value, jsonListOutput, indent, isInArray, d
                 isList && showContent &&
                 <JsonView jsonPath={jsonPath + '/' + field} input={value} indent={indent + 1}
                              deleteNode={deleteNode} setPrimitive={setPrimitive} needLeaf={false}
-                             jsonListOutput={jsonListOutput} createModal={createModal} expandToGeneration={expandToGeneration}/>
+                             jsonListOutput={jsonListOutput} createModal={createModal} expandToGeneration={expandToGeneration} isReadOnly={isReadOnly} />
             }
 
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import UserContext from "./UserContext"
  * @returns {JSX.Element}
  *
  */
-function JsonEditor({jsonObject, onChange, theme, bannerStyle, keyStyle, valueStyle, buttonStyle}) {
+function JsonEditor({jsonObject, onChange, theme, hideInsertObjectButton, expandToGeneration, bannerStyle, keyStyle, valueStyle, buttonStyle}) {
 
     const jsonBoxRef = useRef()
     const defaultStyle = useContext(UserContext)
@@ -27,7 +27,7 @@ function JsonEditor({jsonObject, onChange, theme, bannerStyle, keyStyle, valueSt
             buttons: buttonStyle === undefined ? defaultStyle.buttons : buttonStyle
         }}>
             <div className={styles.container} ref={jsonBoxRef}>
-                <Editor input={jsonObject} jsonBoxRef={jsonBoxRef} onChange={onChange}/>
+                <Editor input={jsonObject} jsonBoxRef={jsonBoxRef} onChange={onChange} hideInsertObjectButton={hideInsertObjectButton} expandToGeneration={expandToGeneration} />
             </div>
         </UserContext.Provider>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import UserContext from "./UserContext"
  * @returns {JSX.Element}
  *
  */
-function JsonEditor({jsonObject, onChange, theme, hideInsertObjectButton, expandToGeneration, bannerStyle, keyStyle, valueStyle, buttonStyle}) {
+function JsonEditor({jsonObject, onChange, theme, hideInsertObjectButton, expandToGeneration, isReadOnly, bannerStyle, keyStyle, valueStyle, buttonStyle}) {
 
     const jsonBoxRef = useRef()
     const defaultStyle = useContext(UserContext)
@@ -27,7 +27,7 @@ function JsonEditor({jsonObject, onChange, theme, hideInsertObjectButton, expand
             buttons: buttonStyle === undefined ? defaultStyle.buttons : buttonStyle
         }}>
             <div className={styles.container} ref={jsonBoxRef}>
-                <Editor input={jsonObject} jsonBoxRef={jsonBoxRef} onChange={onChange} hideInsertObjectButton={hideInsertObjectButton} expandToGeneration={expandToGeneration} />
+                <Editor input={jsonObject} jsonBoxRef={jsonBoxRef} onChange={onChange} hideInsertObjectButton={hideInsertObjectButton} expandToGeneration={expandToGeneration} isReadOnly={isReadOnly} />
             </div>
         </UserContext.Provider>
     )


### PR DESCRIPTION
We like this editor implementation and look and feel, but in order to integrate into our apps, we need to adjust some of its functionality.
This PR adds the following props to the `Editor` component:
* `hideInsertObjectButton`: if `true`, hides the top clickable banner that adds a new object.
* `isReadOnly`: if true, hides the buttons that appear on mouse over to add/edit/delete a field, disable onclick and leaves cursor as default.
* `expandToGeneration`: if specified, only expand the objects and its nested fields to the specified "generation" (by "expand" we mean "show the children nodes"). For example, `0` shows the objects fields, but not their fields content (if they are arrays or objects). `1` would show the objects fields content. `2` would show the objects fields content fields content, and so on and so forth.

If these flags are not specified, the current behavior of this component remains unchanged so that we don't affect current users of the component.